### PR TITLE
Fix for #48

### DIFF
--- a/quarry/net/server.py
+++ b/quarry/net/server.py
@@ -255,7 +255,7 @@ class ServerProtocol(Protocol):
         if self.factory.favicon is not None:
             with open(self.factory.favicon, "rb") as fd:
                 d["favicon"] = "data:image/png;base64," + base64.encodestring(
-                    fd.read()).decode('ascii')
+                    fd.read()).decode('ascii').replace('\n', '')
 
         # send status response
         self.send_packet("status_response", self.buff_type.pack_json(d))


### PR DESCRIPTION
While I don't think reloading the image every single request is a good idea (I think it should be read on load so it's cached and won't crash if the image file doesn't exist or is deleted while the code is running), this does fix this issue and is the quickest possible fix.

_Warning:_ I only tested this patch locally on my 3.7 install when upgrading a project to 1.13, and am making this PR with the GH online editor.