### PR TITLE
Fix default ClientProtocol handling of login_success for 1.16.x

### DIFF
--- a/quarry/net/client.py
+++ b/quarry/net/client.py
@@ -167,7 +167,12 @@ class ClientProtocol(Protocol):
         deferred.addCallbacks(self.auth_ok, self.auth_failed)
 
     def packet_login_success(self, buff):
-        p_uuid = buff.unpack_string()
+        # 1.16.x
+        if self.protocol_version >= 735:
+            p_uuid = buff.unpack_uuid()
+        # 1.15.x
+        else:
+            p_uuid = buff.unpack_string()
         p_display_name = buff.unpack_string()
 
         self.switch_protocol_mode("play")


### PR DESCRIPTION
Unpack logic_success UUID as an UUID instead of a string for protocol versions >= 1.16.x.

This fixes a crash when clients or proxy servers connect to 1.16 servers.