### PR TITLE
fix: use ServerFactory rather than ClientFactory in server example

### DIFF
--- a/docs/networking/writing_servers.rst
+++ b/docs/networking/writing_servers.rst
@@ -34,7 +34,7 @@ servers.
     class ExampleServerProtocol(ServerProtocol):
         pass
 
-    class ExampleServerFactory(ClientFactory):
+    class ExampleServerFactory(ServerFactory):
         protocol = ExampleServerProtocol
 
 


### PR DESCRIPTION
Changed the example server to use a ServerFactory as a base class rather than ClientFactory