### PR TITLE
Fix login_set_compression not sending (47)

### DIFF
--- a/quarry/net/server.py
+++ b/quarry/net/server.py
@@ -43,7 +43,7 @@ class ServerProtocol(Protocol):
         self.check_protocol_mode_switch(mode)
 
         if mode == "play":
-            if self.factory.compression_threshold and self.protocol_version > 47:
+            if self.factory.compression_threshold and self.protocol_version >= 47:
                 # Send set compression
                 self.send_packet(
                     "login_set_compression",


### PR DESCRIPTION
This fixes compression threshold not changing for 1.8.x+ (https://wiki.vg/index.php?title=Protocol&oldid=7368#Set_Compression_2)
the protocol 47 supports it anyways