### PR TITLE
Nicer error handling when there is no content

### DIFF
--- a/quarry/net/http.py
+++ b/quarry/net/http.py
@@ -40,6 +40,12 @@ def request(url, timeout, err_type=Exception, expect_content=False, data=None):
 
     def _callback(response):
         def _callback2(body):
+            if expect_content:
+                if len(body) == 0 or response.code == 204:
+                    err = failure.Failure(err_type(
+                        "No Content",
+                        f"No content was returned by the server for the url {url}"))
+                    d0.errback(err)
             if len(body):
                 d0.callback(json.loads(body.decode('ascii')))
             else:
@@ -54,7 +60,7 @@ def request(url, timeout, err_type=Exception, expect_content=False, data=None):
                 if expect_content:
                     err = failure.Failure(err_type(
                         "No Content",
-                        "No content was returned by the server"))
+                        f"No content was returned by the server for the url {url}"))
                 else:
                     d0.callback(None)
                     return


### PR DESCRIPTION
204 No Content is indicating success
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204

The same check already happend in the error callback but that one does not seem to get hit.

Now the error also contains the url that was expected to return content. So the user knows where to start debugging.

I am currently getting back no content half of the time for this url https://sessionserver.mojang.com/session/minecraft/hasJoined?username=xxx&serverId=xxx&ip=127.0.0.1

and then it crashes with the following error:

```
Traceback (most recent call last):
  File "/home/chiller/Desktop/git/2bored2wait-quarry/venv/lib/python3.10/site-packages/twisted/internet/defer.py", line 1078, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/home/chiller/Desktop/git/quarry/quarry/net/http.py", line 49, in _callback2
    d0.callback(None)
  File "/home/chiller/Desktop/git/2bored2wait-quarry/venv/lib/python3.10/site-packages/twisted/internet/defer.py", line 877, in callback
    self._startRunCallbacks(result)
  File "/home/chiller/Desktop/git/2bored2wait-quarry/venv/lib/python3.10/site-packages/twisted/internet/defer.py", line 984, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/home/chiller/Desktop/git/2bored2wait-quarry/venv/lib/python3.10/site-packages/twisted/internet/defer.py", line 1078, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/home/chiller/Desktop/git/quarry/quarry/net/server.py", line 128, in auth_ok
    self.uuid = UUID.from_hex(data['id'])
builtins.TypeError: 'NoneType' object is not subscriptable
```

Now it prints the following helpful error message:

```
Auth failed: No Content: No content was returned by the server for the url b'https://sessionserver.mojang.com/session/minecraft/hasJoined?username=xxx&serverId=xxx&ip=127.0.0.1
```

# Before

Using the [proxy chat](https://github.com/barneygale/quarry/blob/da88e64e4d841e9c3d23b3614dade041d6613e2a/examples/proxy_hide_chat.py) example with online auth patched in it would occasionally break for me.
Then it crashes on NoneType in the log and the vanilla minecraft client gets stuck in the "Encrypting..." screen.

![image](https://github.com/barneygale/quarry/assets/20344300/26a96879-2480-4447-bcd4-257ba226ae3b)


# After

Now it shows a clear error what went wrong it the log without crashing. And the end user also sees the information.

![new_error_in_proxy](https://github.com/barneygale/quarry/assets/20344300/ca94c0c7-3647-4454-b8b5-a6d260dbf979)
